### PR TITLE
INFRA-332: Use annotation for path in link

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,10 +6,10 @@ dockers:
   - goos: linux
     goarch: amd64
     image_templates:
-      - "registry.banno-internal.com/{{.ProjectName}}:{{.Tag}}"
-      - "registry.banno-internal.com/{{.ProjectName}}:{{.Major}}"
-      - "registry.banno-internal.com/{{.ProjectName}}:{{.Major}}.{{.Minor}}"
-      - "registry.banno-internal.com/{{.ProjectName}}:latest"
+      - "docker.artifactory.banno-tools.com/{{.ProjectName}}:{{.Tag}}"
+      - "docker.artifactory.banno-tools.com/{{.ProjectName}}:{{.Major}}"
+      - "docker.artifactory.banno-tools.com/{{.ProjectName}}:{{.Major}}.{{.Minor}}"
+      - "docker.artifactory.banno-tools.com/{{.ProjectName}}:latest"
     build_flag_templates:
       - "--label=org.label-schema.schema-version=1.0"
       - "--label=org.label-schema.vendor=Jack Henry & Associates"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can pull the docker image from Docker Hub: [`banno/kube-ingress-index`](http
 
 ### Annotations
 
-- `index.ingress.banno.com/ignore`: Set this to have kube-ingress-index not list the Ingress
+- `index.ingress.banno.com/path`: Required annotation specifying the path to build the link with, otherwise, the `Ingress` is ignored
 
 ## Release Steps
 

--- a/go.mod
+++ b/go.mod
@@ -22,3 +22,5 @@ require (
 	k8s.io/utils v0.0.0-20190829053155-3a4a5477acf8 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
[INFRA-332]

Updates to use the annotation `index.ingress.banno.com/path` for the path in the link instead of looking path in the rules.

This also removes the need for the `ignore` annotation since if it does not have the new annotation, it will be ignored.

[INFRA-332]: https://banno-jha.atlassian.net/browse/INFRA-332