### PR TITLE
Update uses: actions/checkout@v2 to uses: actions/checkout@v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Run Tests and Vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v2
         with:
           go-version: 1.18
@@ -21,5 +21,5 @@ jobs:
     name: Build docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: docker build .


### PR DESCRIPTION
This PR updates uses: actions/checkout@v2 to uses: actions/checkout@v4