### PR TITLE
Add permissions for workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,10 @@
 name: CI
 
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: "write"
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
To fix https://github.com/Banno/kube-ingress-index/security/code-scanning/1 and https://github.com/Banno/kube-ingress-index/security/code-scanning/2.